### PR TITLE
fix(build): fix Forge app build to produce correct file structure

### DIFF
--- a/packages/forge/src/executors/build/lib/compile-webpack.ts
+++ b/packages/forge/src/executors/build/lib/compile-webpack.ts
@@ -11,10 +11,11 @@ export function compileWebpack(
   outfile: string;
 }> {
   const builderOptions: BuildNodeBuilderOptions = {
-    outputPath: joinPathFragments('dist', options.projectRoot),
+    outputPath: joinPathFragments(options.outputPath, 'src'),
+    outputFileName: 'index.js',
     tsConfig: `${options.projectRoot}/tsconfig.app.json`,
     main: `${options.projectRoot}/src/index.ts`,
-    generatePackageJson: true,
+    generatePackageJson: false,
     assets: [],
     watch: options.watch,
     transformers: [],

--- a/packages/forge/src/executors/build/lib/copy-forge-app-assets.ts
+++ b/packages/forge/src/executors/build/lib/copy-forge-app-assets.ts
@@ -11,6 +11,8 @@ export function copyForgeAppAssets(options: NormalizedOptions) {
     mkdirSync(options.outputPath, { recursive: true });
   }
 
+  // Copies the Forge app manifest file from the project root directory into the
+  // build output directory.
   copyFileSync(
     join(options.root, options.projectRoot, 'manifest.yml'),
     join(options.outputPath, 'manifest.yml')


### PR DESCRIPTION
fix Forge app build to ensure Webpack produces the output file in the correct directory and that package.json is not produced twice

Closes: #15