### PR TITLE
fix(build): fix Forge app build to keep external dependencies external

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'test-*'
 jobs:
   release:
     name: Release

--- a/packages/forge/src/executors/build/lib/compile-webpack.ts
+++ b/packages/forge/src/executors/build/lib/compile-webpack.ts
@@ -21,7 +21,7 @@ export function compileWebpack(
     transformers: [],
     fileReplacements: [],
     extractLicenses: false,
-    externalDependencies: 'none',
+    externalDependencies: 'all',
   };
 
   return webpackExecutor(builderOptions, context);


### PR DESCRIPTION
fix Forge app build to ensure Webpack does not bundle external dependencies

Closes: #17