### PR TITLE
fix(build): fix executors to account for sub-directories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,9 @@ To publish packages to a local registry, do the following:
 2. Start Verdaccio by running `verdaccio` in a terminal
 3. From the plugin project root run `nx build forge`
 4. Make sure the `version` field in `dist/packages/forge/package.json` is unique (not yet published, you may use `9.9.9-alpha.1` and increase the alpha count on each subsequent release).
-5. From `dist/packages/forge` run `npm publish --registry=http://localhost:4873/`
-6. On the consumer side you can now install the latest package version by running `npm i @toolsplus/nx-forge@latest --registry=http://localhost:4873`
+5. Run `npm adduser --registry=http://localhost:4873/` (real credentials are not required, you just need to be logged in. You can use test/test/test@test.io.)
+6. From `dist/packages/forge` run `npm publish --registry=http://localhost:4873/`
+7.On the consumer side you can now install the latest package version by running `npm i @toolsplus/nx-forge@latest --registry=http://localhost:4873`
 
 ## Migrate to a newer Nx version
 

--- a/e2e/forge-e2e/jest.config.js
+++ b/e2e/forge-e2e/jest.config.js
@@ -12,4 +12,5 @@ module.exports = {
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/e2e/forge-e2e',
   preset: '../../jest.preset.js',
+  testTimeout: 240000, // set the default test timeout to 2min for all e2e tests
 };

--- a/e2e/forge-e2e/tests/custom-cache.spec.ts
+++ b/e2e/forge-e2e/tests/custom-cache.spec.ts
@@ -3,7 +3,13 @@ import { updateFile } from '@nx/plugin/src/utils/testing-utils/utils';
 import { generateForgeApp } from './utils/generate-app';
 import { ensureCorrectWorkspaceRoot } from './utils/e2e-workspace';
 
-describe('forge app with custom Nx caching', () => {
+/**
+ * Note, running this test in parallel with other tests may fail because this is changing a
+ * Nx workspace setting which will cause running tests to fail unexpectedly.
+ *
+ * Use the `--runInBand` option to make sure tests run sequentially.
+ */
+describe('Forge app with custom Nx caching', () => {
   beforeAll(() => {
     ensureNxProject('@toolsplus/nx-forge', 'dist/packages/forge');
     ensureCorrectWorkspaceRoot();
@@ -33,5 +39,5 @@ describe('forge app with custom Nx caching', () => {
 
     const resultAfterCustomCache = await runNxCommandAsync(`build ${appName}`);
     expect(resultAfterCustomCache.stdout).toContain('Executor ran');
-  }, 240000);
+  });
 });

--- a/e2e/forge-e2e/tests/forge-app-generate.spec.ts
+++ b/e2e/forge-e2e/tests/forge-app-generate.spec.ts
@@ -7,7 +7,7 @@ import {
 import { generateForgeApp } from './utils/generate-app';
 import { ensureCorrectWorkspaceRoot } from './utils/e2e-workspace';
 
-describe('forge app generate', () => {
+describe('Forge app generate', () => {
   beforeAll(() => {
     ensureNxProject('@toolsplus/nx-forge', 'dist/packages/forge');
     ensureCorrectWorkspaceRoot();
@@ -26,9 +26,9 @@ describe('forge app generate', () => {
     expect(() => checkFilesExist(`apps/${appName}/package.json`)).not.toThrow();
     expect(() => checkFilesExist(`apps/${appName}/src/index.ts`)).not.toThrow();
 
-    const result = await runNxCommandAsync(`build ${appName}`);
-    expect(result.stdout).toContain('Executor ran');
-  }, 240000);
+    const nxBuildResult = await runNxCommandAsync(`build ${appName}`);
+    expect(nxBuildResult.stdout).toContain('Executor ran');
+  });
 
   describe('--directory', () => {
     it('should create Forge app with src in the specified directory', async () => {
@@ -44,14 +44,19 @@ describe('forge app generate', () => {
       expect(() =>
         checkFilesExist(`apps/${subdir}/${appName}/src/index.ts`)
       ).not.toThrow();
-    }, 240000);
+
+      const nxBuildResult = await runNxCommandAsync(
+        `build ${subdir}-${appName}`
+      );
+      expect(nxBuildResult.stdout).toContain('Executor ran');
+    });
   });
 
   describe('--tags', () => {
     it('should create Forge app with tags added to the project', async () => {
-      const plugin = await generateForgeApp(`--tags e2etag,e2ePackage`);
-      const project = readJson(`apps/${plugin}/project.json`);
+      const appName = await generateForgeApp(`--tags e2etag,e2ePackage`);
+      const project = readJson(`apps/${appName}/project.json`);
       expect(project.tags).toEqual(['e2etag', 'e2ePackage']);
-    }, 240000);
+    });
   });
 });

--- a/packages/forge/src/executors/build/lib/process-custom-ui-dependencies.ts
+++ b/packages/forge/src/executors/build/lib/process-custom-ui-dependencies.ts
@@ -25,8 +25,7 @@ export async function processCustomUIDependencies(
 ): Promise<Resources> {
   const manifestPath = joinPathFragments(
     context.root,
-    'apps',
-    context.projectName,
+    context.projectsConfigurations.projects[context.projectName].root,
     'manifest.yml'
   );
   const manifestSchema = await loadManifestYml(manifestPath);

--- a/packages/forge/src/executors/tunnel/lib/extract-custom-ui-projects.ts
+++ b/packages/forge/src/executors/tunnel/lib/extract-custom-ui-projects.ts
@@ -39,8 +39,7 @@ async function extractVerifiedCustomUiProjects(
 ): Promise<ResourceWithTunnelPort[]> {
   const manifestPath = joinPathFragments(
     context.root,
-    'apps',
-    context.projectName,
+    context.projectsConfigurations.projects[context.projectName].root,
     'manifest.yml'
   );
   const manifestSchema = await loadManifestYml(manifestPath);


### PR DESCRIPTION
fix manifest.yml path construction to use the actual project root in build and tunnel executors

Closes: #38