### PR TITLE
feat: add install executor for forge apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         run: |
           echo FORGE_EMAIL=${{ secrets.FORGE_EMAIL }} >> e2e/forge-e2e/.env
           echo FORGE_API_TOKEN=${{ secrets.FORGE_API_TOKEN }} >> e2e/forge-e2e/.env
+          echo ATLASSIAN_PRODUCT=${{ vars.ATLASSIAN_PRODUCT }} >> e2e/forge-e2e/.env
+          echo ATLASSIAN_SITE_URL=${{ vars.ATLASSIAN_SITE_URL }} >> e2e/forge-e2e/.env
       - run: npm ci
       - run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
       - run: npx nx affected --target=format:check --parallel=2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
         run: |
           echo FORGE_EMAIL=${{ secrets.FORGE_EMAIL }} >> e2e/forge-e2e/.env
           echo FORGE_API_TOKEN=${{ secrets.FORGE_API_TOKEN }} >> e2e/forge-e2e/.env
+          echo ATLASSIAN_PRODUCT=${{ vars.ATLASSIAN_PRODUCT }} >> e2e/forge-e2e/.env
+          echo ATLASSIAN_SITE_URL=${{ vars.ATLASSIAN_SITE_URL }} >> e2e/forge-e2e/.env
       - name: Install dependencies
         run: npm ci
       - name: Build and test

--- a/e2e/forge-e2e/.env.example
+++ b/e2e/forge-e2e/.env.example
@@ -1,11 +1,16 @@
 # Some E2E tests require access to an Atlassian Developer account to
 # test using the Forge CLI and clean up after tests have run.
 #
-# Copy this file into a file called .env in the same directory and
-# update the variable values with the desired developer account
-#
-# If you need to generate an API token go to: https://id.atlassian.com/manage-profile/security/api-tokens
-#
+# Copy this file into a file called .env in the same directory and update the variable values with
+# the desired developer account, site and product.
+
 # https://developer.atlassian.com/platform/forge/getting-started/#using-environment-variables-to-login
 FORGE_EMAIL=email@example.com
+
+# If you need to generate an API token go to: https://id.atlassian.com/manage-profile/security/api-tokens
 FORGE_API_TOKEN=my-api-token
+
+ATLASSIAN_SITE_URL=my-jira-site.atlassian.net
+
+# jira, confluence, compass
+ATLASSIAN_PRODUCT=jira

--- a/e2e/forge-e2e/tests/install.executor.spec.ts
+++ b/e2e/forge-e2e/tests/install.executor.spec.ts
@@ -3,22 +3,34 @@ import {
   readFile,
   runCommandAsync,
   runNxCommandAsync,
+  tmpProjPath,
 } from '@nx/plugin/testing';
 import { GraphQLClient } from 'graphql-request';
 import { ensureCorrectWorkspaceRoot } from './utils/e2e-workspace';
 import { generateForgeApp } from './utils/generate-forge-app';
-import { Credentials, getCredentials } from './utils/config';
+import {
+  AtlassianProductContext,
+  Credentials,
+  getAtlassianProductContext,
+  getCredentials,
+} from './utils/config';
 import { createClient, deleteApp } from './utils/atlassian-graphql-client';
+import { runForgeCommandAsync } from './utils/async-commands';
+import { getInstallationIds } from './utils/installation-ids';
+import { joinPathFragments } from '@nx/devkit';
 
-describe('Forge deploy executor', () => {
-  let developerCredentials: Credentials; // initialize before all tests
+describe('Forge install executor', () => {
+  // initialize before all tests
+  let developerCredentials: Credentials;
   let apiClient: GraphQLClient;
+  let productContext: AtlassianProductContext;
 
   beforeAll(async () => {
     ensureNxProject('@toolsplus/nx-forge', 'dist/packages/forge');
     ensureCorrectWorkspaceRoot();
     developerCredentials = getCredentials();
     apiClient = createClient(developerCredentials);
+    productContext = getAtlassianProductContext();
 
     // Initialize the Forge CLI, otherwise commands may fail due to expected interactive input
     await runCommandAsync(`npx forge settings set usage-analytics false`, {
@@ -32,7 +44,7 @@ describe('Forge deploy executor', () => {
     await runNxCommandAsync('reset');
   });
 
-  it('should deploy a Forge app', async () => {
+  it('should install a Forge app', async () => {
     const appName = await generateForgeApp();
     const nxBuildResult = await runNxCommandAsync(`build ${appName}`, {
       silenceError: true,
@@ -56,6 +68,30 @@ describe('Forge deploy executor', () => {
     expect(nxDeployResult.stderr).toEqual('');
     expect(nxDeployResult.stdout).toContain('Forge app deployed');
 
+    const nxInstallResult = await runNxCommandAsync(
+      `install ${appName} --product=${productContext.product} --site=${productContext.siteUrl} --no-interactive`,
+      {
+        silenceError: true,
+      }
+    );
+    expect(nxInstallResult.stderr).toEqual('');
+    expect(nxInstallResult.stdout).toContain('Forge app installed');
+
+    // Clean up
+    const installationIds = await getInstallationIds(appName);
+    const uninstallResults = await Promise.all(
+      installationIds.map(({ id }) =>
+        runForgeCommandAsync(`uninstall ${id}`, {
+          cwd: joinPathFragments(tmpProjPath(), 'dist', 'apps', appName),
+          silenceError: true,
+        })
+      )
+    );
+    uninstallResults.forEach((result) => {
+      expect(result.stderr).toEqual('');
+      expect(result.stdout).toContain('Uninstalled');
+    });
+
     // ari:cloud:ecosystem::app/<uuid>
     const registeredAppIdRegex =
       /ari:cloud:ecosystem::app\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
@@ -63,9 +99,17 @@ describe('Forge deploy executor', () => {
     const registeredOutputManifestContent = readFile(
       `dist/apps/${appName}/manifest.yml`
     );
-    const [appId] = registeredOutputManifestContent.match(registeredAppIdRegex);
+    const appIdMatch =
+      registeredOutputManifestContent.match(registeredAppIdRegex);
 
-    // Clean up the registered app
+    if (!appIdMatch) {
+      throw new Error(
+        'Unexpected error during clean up: Failed to detect app id in manifest.yml'
+      );
+    }
+
+    const [appId] = appIdMatch;
+
     const result = await deleteApp(appId)(apiClient);
     if (!result.success) {
       throw new Error(

--- a/e2e/forge-e2e/tests/utils/async-commands.ts
+++ b/e2e/forge-e2e/tests/utils/async-commands.ts
@@ -1,0 +1,41 @@
+import { exec } from 'child_process';
+import { getPackageManagerCommand } from '@nx/devkit';
+import { tmpProjPath } from '@nx/plugin/testing';
+
+/**
+ * Runs the given Forge CLI command asynchronously inside the e2e directory (if cwd is not provided).
+ *
+ * Note that this implementation is only meant to be used in testing code. It is using `exec`
+ * to run the Forge CLI command. `exec` returns `stdout` and `stderr` as strings which is convenient
+ * for validating or processing the console output in tests.
+ *
+ * @see https://github.com/nrwl/nx/blob/e8c31d7ac72a6eeb98d07b61f6ae945a2612d8ac/packages/plugin/src/utils/testing-utils/async-commands.ts#L40
+ *
+ * @param command Forge CLI command to execute, e.g. lint, install, register
+ * @param opts Execution options
+ * @returns Console outputs
+ */
+export const runForgeCommandAsync = (
+  command: string,
+  opts: { silenceError?: boolean; env?: NodeJS.ProcessEnv; cwd?: string } = {
+    silenceError: false,
+  }
+): Promise<{ stdout: string; stderr: string }> => {
+  const pmc = getPackageManagerCommand();
+  return new Promise((resolve, reject) => {
+    exec(
+      `${pmc.exec} forge ${command}`,
+      {
+        cwd: opts.cwd ?? tmpProjPath(),
+        env: { ...process.env, ...opts.env },
+      },
+      (err, stdout, stderr) => {
+        if (!opts.silenceError && err) {
+          console.error('Failed to run Forge command:', err, stdout, stderr);
+          reject(err);
+        }
+        resolve({ stdout, stderr });
+      }
+    );
+  });
+};

--- a/e2e/forge-e2e/tests/utils/installation-ids.ts
+++ b/e2e/forge-e2e/tests/utils/installation-ids.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { joinPathFragments } from '@nx/devkit';
+import { tmpProjPath } from '@nx/plugin/testing';
+import { runForgeCommandAsync } from './async-commands';
+
+/**
+ * Schema that describes the Forge CLI JSON output of running `forge install list`
+ *
+ * You may add more properties to the schema, however, to keep this as robust as possible only
+ * add the properties that are actually needed.
+ *
+ * Below an example of the expected output:
+ *
+ * [
+ *   {
+ *     "id": "1cdbd223-3579-4bea-a5d2-8ba855c2241d",
+ *     "environment": "development",
+ *     "site": "my-site.atlassian.net",
+ *     "product": "Jira",
+ *     "version": "Latest"
+ *   }
+ * ]
+ *
+ * @see https://developer.atlassian.com/platform/forge/cli-reference/install/#commands
+ */
+const installationListSchema = z.array(
+  z.object({
+    id: z.string(),
+  })
+);
+
+/**
+ * Retrieves the installation ids for the current app by running `forge install list`.
+ *
+ * This runs the command in the e2e directory.
+ *
+ * @param projectName Name of the Nx app project for which to get installation ids
+ * @returns List of installation ids for the given app project
+ */
+export const getInstallationIds = async (
+  projectName
+): Promise<z.infer<typeof installationListSchema>> => {
+  const listInstallationResult = await runForgeCommandAsync(
+    'install list --json',
+    {
+      cwd: joinPathFragments(tmpProjPath(), 'dist', 'apps', projectName),
+      silenceError: true,
+    }
+  );
+  const rawInstallationsJson = JSON.parse(listInstallationResult.stdout);
+  return installationListSchema.parse(rawInstallationsJson);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,8 @@
         "ts-jest": "29.1.0",
         "ts-node": "10.9.1",
         "tslib": "^2.3.0",
-        "typescript": "4.9.5"
+        "typescript": "4.9.5",
+        "zod": "^3.21.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -29801,6 +29802,15 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -52424,6 +52434,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1",
     "tslib": "^2.3.0",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "zod": "^3.21.4"
   },
   "dependencies": {
     "@fastify/autoload": "~5.7.1",

--- a/packages/forge/README.md
+++ b/packages/forge/README.md
@@ -145,9 +145,9 @@ Then run
 
 to deploy the Forge app to the default development environment.
 
-Finally go to `dist/apps/<forge-app-name>` and run the following command
+Finally, install the app in any of your sites with the following command
   
-    forge install
+    nx install <forge-app-name>
 
 The Forge app is now registered, deployed and installed with the Forge platform.
 
@@ -155,20 +155,21 @@ That's it for the setup steps. You can now generate additional Custom UI resourc
 
 ## Using the Nx Forge plugin
 
-### Register
+For any of the plugin targets below append `--help` or `-h` to explore all available options.
 
+### Register
 Run `nx register <forge-app-name>` to register the Forge app with the Forge platform.
 
 ### Build
-
 Run `nx build <forge-app-name>` to build the project. The build artifacts will be stored in the `dist/` directory.
 
 ### Deploy
-
 Run `nx deploy <forge-app-name>` to deploy the project. The build artifacts will be deployed using the Forge CLI deploy command.
 
-### Tunnel
+### Install
+Run `nx install <forge-app-name>` to install the Forge app. The CLI will prompt for site, product if they are not provided as parameters.
 
+### Tunnel (experimental)
 Run `nx serve <forge-app-name>` to serve the project. This will start the `serve` target for all Custom UI projects defined in the app `manifest.yml` on their specified tunnel port. After that, it will start a build process in watch mode for the Forge app itself, before ultimately, starting the `forge tunnel` process for the Forge app.
 
 ## Further help on how to develop with Nx

--- a/packages/forge/executors.json
+++ b/packages/forge/executors.json
@@ -20,6 +20,11 @@
       "implementation": "./src/executors/tunnel/executor",
       "schema": "./src/executors/tunnel/schema.json",
       "description": "tunnel executor"
+    },
+    "install": {
+      "implementation": "./src/executors/install/executor",
+      "schema": "./src/executors/install/schema.json",
+      "description": "install executor"
     }
   }
 }

--- a/packages/forge/src/executors/build/executor.ts
+++ b/packages/forge/src/executors/build/executor.ts
@@ -12,7 +12,8 @@ export default async function runExecutor(
   rawOptions: BuildExecutorOptions,
   context: ExecutorContext
 ) {
-  const { root, sourceRoot } = context.workspace.projects[context.projectName];
+  const { root, sourceRoot } =
+    context.projectsConfigurations!.projects[context.projectName!];
 
   if (!sourceRoot) {
     throw new Error(`${context.projectName} does not have a sourceRoot.`);
@@ -37,8 +38,8 @@ export default async function runExecutor(
   const customUIResources = await processCustomUIDependencies(options, context);
   await patchManifestYml(options);
   generatePackageJson(
-    context.projectName,
-    context.projectGraph,
+    context.projectName!,
+    context.projectGraph!,
     customUIResources,
     options
   );

--- a/packages/forge/src/executors/install/executor.ts
+++ b/packages/forge/src/executors/install/executor.ts
@@ -1,0 +1,29 @@
+import { InstallExecutorOptions } from './schema';
+import { logger } from '@nx/devkit';
+import { runForgeCommandAsync } from '../../utils/forge/async-commands';
+
+export default async function runExecutor(options: InstallExecutorOptions) {
+  // https://developer.atlassian.com/platform/forge/cli-reference/install/
+  const args = [
+    'install',
+    `--site=${options.site}`,
+    `--product=${options.product}`,
+    `--environment=${options.environment}`,
+    ...(options.upgrade === true ? ['--upgrade'] : []),
+    ...(options.confirmScopes === true ? ['--confirm-scopes'] : []),
+    ...(options.interactive === false ? ['--non-interactive'] : []),
+    ...(options.verbose === true ? ['--verbose'] : []),
+  ];
+
+  logger.log(`Running: forge ${args.join(' ')}`);
+
+  await runForgeCommandAsync(args, {
+    cwd: options.outputPath,
+  });
+
+  logger.info('✅ Forge app installed');
+
+  return {
+    success: true,
+  };
+}

--- a/packages/forge/src/executors/install/schema.d.ts
+++ b/packages/forge/src/executors/install/schema.d.ts
@@ -1,0 +1,10 @@
+export interface InstallExecutorOptions {
+  outputPath: string;
+  site: string;
+  product: 'jira' | 'confluence' | 'compass';
+  environment: 'development' | 'staging' | 'production';
+  upgrade: boolean;
+  confirmScopes: boolean;
+  interactive: boolean;
+  verbose: boolean;
+}

--- a/packages/forge/src/executors/install/schema.json
+++ b/packages/forge/src/executors/install/schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "version": 2,
+  "title": "Forge application install target",
+  "description": "Manage app installations",
+  "type": "object",
+  "properties": {
+    "outputPath": {
+      "type": "string",
+      "description": "The output path of the Forge app files.",
+      "visible": false
+    },
+    "site":  {
+      "type": "string",
+      "description": "Atlassian site URL (example.atlassian.net)",
+      "alias": "s"
+    },
+    "product": {
+      "type": "string",
+      "description": "Atlassian product: jira, confluence, compass",
+      "enum": [
+        "jira",
+        "confluence",
+        "compass"
+      ],
+      "alias": "p"
+    },
+    "environment": {
+      "type": "string",
+      "enum": [
+        "development",
+        "staging",
+        "production"
+      ],
+      "description": "Environment to install to: development, staging, production.",
+      "alias": "e",
+      "default": "development"
+    },
+    "upgrade": {
+      "type": "boolean",
+      "description": "Upgrade an existing installation.",
+      "default": false
+    },
+    "confirmScopes": {
+      "type": "boolean",
+      "description": "Skip confirmation of scopes for the app before installing or upgrading the app.",
+      "default": false
+    },
+    "interactive": {
+      "type": "boolean",
+      "description": "Run installation with or without input prompts.",
+      "default": true
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Run installation in verbose mode.",
+      "alias": "v",
+      "default": false
+    }
+  },
+  "required": [
+    "outputPath",
+    "site",
+    "product"
+  ]
+}

--- a/packages/forge/src/executors/register/schema.json
+++ b/packages/forge/src/executors/register/schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/schema",
   "version": 2,
   "title": "Forge application register target",
-  "description": "",
+  "description": "Register an app you didn't create so you can run commands for it",
   "type": "object",
   "properties": {
     "outputPath": {

--- a/packages/forge/src/generators/application/generator.spec.ts
+++ b/packages/forge/src/generators/application/generator.spec.ts
@@ -17,6 +17,18 @@ describe('application generator', () => {
       const project = readProjectConfiguration(tree, 'my-app');
 
       expect(project.root).toEqual('apps/my-app');
+
+      const executor = (name: string) => `@toolsplus/nx-forge:${name}`;
+      const expectedExecutorTargets = [
+        ['register', 'register'],
+        ['build', 'build'],
+        ['serve', 'tunnel'],
+        ['deploy', 'deploy'],
+        ['install', 'install'],
+      ];
+      expectedExecutorTargets.forEach(([target, executorName]) =>
+        expect(project.targets[target].executor).toEqual(executor(executorName))
+      );
     });
 
     it('should add tags to project config', async () => {

--- a/packages/forge/src/generators/application/lib/add-project.ts
+++ b/packages/forge/src/generators/application/lib/add-project.ts
@@ -9,6 +9,7 @@ import { getRegisterConfig } from './get-register-config';
 import { getBuildConfig } from './get-build-config';
 import { getDeployConfig } from './get-deploy-config';
 import { getServeConfig } from './get-serve-config';
+import { getInstallConfig } from './get-install-config';
 
 /**
  * Generate the new Forge app project in the workspace and configure
@@ -23,10 +24,12 @@ export function addProject(tree: Tree, options: NormalizedOptions) {
     tags: options.parsedTags,
   };
 
+  project.targets = {};
   project.targets.register = getRegisterConfig(project, options);
   project.targets.build = getBuildConfig(project, options);
   project.targets.serve = getServeConfig(project, options);
   project.targets.deploy = getDeployConfig(project, options);
+  project.targets.install = getInstallConfig(project, options);
 
   addProjectConfiguration(
     tree,

--- a/packages/forge/src/generators/application/lib/get-install-config.ts
+++ b/packages/forge/src/generators/application/lib/get-install-config.ts
@@ -1,0 +1,18 @@
+import { NormalizedOptions } from '../schema';
+import {
+  joinPathFragments,
+  ProjectConfiguration,
+  TargetConfiguration,
+} from '@nx/devkit';
+
+export function getInstallConfig(
+  project: ProjectConfiguration,
+  options: NormalizedOptions
+): TargetConfiguration {
+  return {
+    executor: '@toolsplus/nx-forge:install',
+    options: {
+      outputPath: joinPathFragments('dist', options.appProjectRoot),
+    },
+  };
+}

--- a/packages/forge/src/generators/application/schema.d.ts
+++ b/packages/forge/src/generators/application/schema.d.ts
@@ -1,3 +1,5 @@
+import type { Linter } from '@nx/linter';
+
 export interface ApplicationGeneratorOptions {
   name: string;
   directory?: string;
@@ -13,7 +15,7 @@ export interface ApplicationGeneratorOptions {
 
 interface NormalizedOptions extends ApplicationGeneratorOptions {
   appProjectRoot: string;
-  linter: Exclude<Linter, Linter.TsLint>;
+  linter: Linter;
   unitTestRunner: UnitTestRunner;
   parsedTags: string[];
 }

--- a/packages/forge/src/utils/forge/load-manifest-yml.ts
+++ b/packages/forge/src/utils/forge/load-manifest-yml.ts
@@ -16,9 +16,13 @@ export async function loadManifestYml(
     errors,
   } = await new ManifestYmlValidator().process(manifestPath);
 
-  if (!isManifestParseSuccess) {
+  if (
+    !isManifestParseSuccess ||
+    !manifestObject ||
+    !manifestObject.typedContent
+  ) {
     throw new Error(
-      `Failed to parse manifest.yml (${manifestPath}): ${errors
+      `Failed to parse manifest.yml (${manifestPath}): ${(errors || [])
         .map((e) => e.message)
         .join('\n')}`
     );


### PR DESCRIPTION
add a install executor that allows Forge apps to be installed with the Forge platform update Forge application generator to generate install target using the new install executor

Closes: #29