### PR TITLE
fix: run Forge commands inside of a shell

### DIFF
--- a/packages/nx-forge/src/utils/forge/async-commands.ts
+++ b/packages/nx-forge/src/utils/forge/async-commands.ts
@@ -16,6 +16,7 @@ export const runForgeCommandAsync = (
     cwd: opts.cwd,
     env: { ...process.env, ...opts.env },
     stdio: [process.stdin, process.stdout, process.stderr],
+    shell: true,
   });
   return new Promise((resolve, reject) => {
     cliProcess.once('exit', (code: number) => {


### PR DESCRIPTION
spawn Forge commands inside of a shell to work properly in CI