### PR TITLE
Fix package executor copy manifest to output

### DIFF
--- a/packages/nx-forge/src/executors/build/lib/copy-forge-app-assets.ts
+++ b/packages/nx-forge/src/executors/build/lib/copy-forge-app-assets.ts
@@ -15,7 +15,9 @@ function directoryExists(path: PathLike): boolean {
   }
 }
 
-export function copyForgeAppAssets(options: NormalizedOptions) {
+type Options = Pick<NormalizedOptions, 'root' | 'outputPath' | 'projectRoot'>;
+
+export function copyForgeAppAssets(options: Options) {
   logger.info('Copying Forge app assets...');
 
   const absoluteOutputPath = resolve(options.root, options.outputPath);

--- a/packages/nx-forge/src/executors/package/executor.ts
+++ b/packages/nx-forge/src/executors/package/executor.ts
@@ -3,6 +3,7 @@ import { NormalizedOptions, PackageExecutorSchema } from './schema';
 import { processCustomUIDependencies } from '../build/lib/process-custom-ui-dependencies';
 import { patchManifestYml } from '../build/lib/patch-manifest-yml';
 import { generatePackageJson } from '../build/lib/generate-package-json';
+import { copyForgeAppAssets } from '../build/lib/copy-forge-app-assets';
 
 export function normalizeOptions(
   options: PackageExecutorSchema,
@@ -35,6 +36,8 @@ export default async function runExecutor(
   }
 
   const options = normalizeOptions(rawOptions, context.root, sourceRoot, root);
+
+  copyForgeAppAssets(options);
 
   const customUIResources = await processCustomUIDependencies(
     { ...options, customUIPath: options.resourcePath },


### PR DESCRIPTION
Update the package executor to copy the manifest.yml to the output directory. This should not be the responsibility of the build task.