### PR TITLE
feat(executors): improve manifestTransform env function

### DIFF
--- a/docs/guides/transforming-the-manifest.md
+++ b/docs/guides/transforming-the-manifest.md
@@ -6,7 +6,20 @@ To transform the manifest file, Nx Forge expects the `manifestTransform` to be a
 
 ## Developing and testing manifest transforms
 
-To develop manifest transform expressions, convert the manifest YAML content to JSON and paste it into [the JSONata exerciser](https://try.jsonata.org/), allowing you to test JSONata expressions. 
+To develop manifest transform expressions, convert the manifest YAML content to JSON and paste it into [the JSONata exerciser](https://try.jsonata.org/), allowing you to test JSONata expressions.
+
+If you are [injecting environment variables in your expression](#using-environment-variables-in-transforms), you may want to use the following code block to emulate the `$env` function:
+
+```jsonata
+(
+    $env := $lookup({
+        'CONNECT_APP_KEY': 'io.toolsplus.hello',
+        'CONNECT_REMOTE_BASE_URL': 'https://connect-base-url.com'
+    }, ?);
+    
+    $ ~> |app.connect|{'key': $env('CONNECT_APP_KEY')}| ~> |remotes[key='connect']|{'baseUrl': $env('CONNECT_REMOTE_BASE_URL')}|
+)
+```
 
 ## Manifest transform examples
 
@@ -34,12 +47,12 @@ $
 ~> |app|{'id': 'ari:cloud:ecosystem::app/407bc6a8-...'}|
 ~> |app|{'licensing': {'enabled': true}}|
 ~> |app.connect|{'key': 'my-connect-key'}| 
-~> |remotes|{'baseUrl': 'https://my-connect-base-url.com?source=forge'}|
+~> |remotes|{'baseUrl': 'https://my-connect-base-url.com'}|
 ```
 
 ## Using environment variables in transforms
 
-Nx Forge provides the function `$env(string): string|null` to allow `manifestTransform` expressions to read environment variables at runtime. Inject environment variables into an expression using the `$env()` function, as shown in the example below.
+Nx Forge provides two functions `$env(string): string` and `$envOrNull(string): string|null` to allow `manifestTransform` expressions to read environment variables at runtime. Prefer the `$env()` function to inject environment variables, as this will throw and abort the deployment process if the variable is undefined. 
 
 ```jsonata
 $ 
@@ -61,7 +74,7 @@ Nx executors accept a [`configurations` property](https://nx.dev/concepts/execut
       },
       "configurations": {
         "development-exra": {
-          "manifestTransform": "$ ~> |app|{'licensing': {'enabled': false}}| ~> |remotes|{'baseUrl': 'https://my-local-connect-base-url.com?source=forge'}|"
+          "manifestTransform": "$ ~> |app|{'licensing': {'enabled': false}}| ~> |remotes|{'baseUrl': 'https://my-local-connect-base-url.com'}|"
         },
         "development": {
           "manifestTransform": "$ ~> |app|{'licensing': {'enabled': false}}|"

--- a/packages/nx-forge/src/executors/deploy/lib/transform-manifest-yml.ts
+++ b/packages/nx-forge/src/executors/deploy/lib/transform-manifest-yml.ts
@@ -35,7 +35,18 @@ export const transformManifestYml = async (
 
   const manifest = await readManifestYml(manifestPath);
 
-  expression.registerFunction('env', (s) => process.env[s], '<s:(sl)>');
+  expression.registerFunction(
+    'env',
+    (s) => {
+      if (process.env[s]) {
+        return process.env[s];
+      } else {
+        throw new Error(`Environment variable '${s}' is not defined`);
+      }
+    },
+    '<s:(s)>'
+  );
+  expression.registerFunction('envOrNull', (s) => process.env[s], '<s:(sl)>');
 
   const transformedManifest = await expression.evaluate(manifest);
 


### PR DESCRIPTION
Update the provided `$env` function in JSONata  `manifestTransform` to throw if an environment variable is not defined. This is safer than returning null as it will not fail silently and abort the deployment process. If `null` is acceptable, `$envOrNull` has been added.