### PR TITLE
ci: fix semantic release rate limit error

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -10,7 +10,10 @@
     ["@semantic-release/npm", {
       "pkgRoot": "dist/packages/nx-forge"
     }],
-    "@semantic-release/github"
+    ["@semantic-release/github", {
+      "successComment": false,
+      "failTitle": false
+    }]
   ],
   "preset": "angular"
 }


### PR DESCRIPTION
disable semantic release success comments to fix Github rate limits as suggested here: https://github.com/semantic-release/semantic-release/issues/2204#issuecomment-1486299917