### PR TITLE
fix(generators): fix Webpack config template

### DIFF
--- a/packages/nx-forge/src/generators/application/files/webpack.config.js__tmpl__
+++ b/packages/nx-forge/src/generators/application/files/webpack.config.js__tmpl__
@@ -5,6 +5,9 @@ const { join } = require('path');
 module.exports = {
   output: {
     path: join(__dirname, '<%= offset %><%= webpackPluginOptions.outputPath %>'),
+    library: {
+      type: 'commonjs2',
+    },
   },
   plugins: [
     new NxAppWebpackPlugin({


### PR DESCRIPTION
fix the Webpack configuration template to include the `output.library.type` option as `commonjs2`

Closes #127