### PR TITLE
ci: fix node lts version

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -18,7 +18,7 @@ jobs:
         name: Derive appropriate SHAs for base and head for `nx affected` commands
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/-1'
       - run: npm ci
       - run: npx nx affected --target=build --parallel=2
       - run: npx nx affected --target=test --parallel=2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v4
         name: Setup Node.js
         with:
-          node-version: 'lts/*'
+          node-version: 'lts/-1'
       - name: 'Create E2E env file'
         run: |
           echo FORGE_EMAIL=${{ secrets.FORGE_EMAIL }} >> e2e/nx-forge-e2e/.env


### PR DESCRIPTION
there is an issue with ts-node and as a result ts-jest that does not work with the latest Node LTS version 22.x.