### PR TITLE
Update @forge/manifest in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fastify/autoload": "~5.7.1",
         "@fastify/sensible": "~5.2.0",
-        "@forge/manifest": "^8.1.0",
+        "@forge/manifest": "^8.2.0",
         "@swc/helpers": "0.5.11",
         "axios": "1.6.7",
         "fastify": "~4.13.0",
@@ -13221,9 +13221,9 @@
       }
     },
     "node_modules/@forge/manifest": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-8.1.0.tgz",
-      "integrity": "sha512-cZx9n+d1ezG2z0Y211vzHgaXF09qTsrhTZnmVY8oTu+wR99tXu0UICHeq3Zb0fDXjvJJUymo+4s1gYjUJu9ShQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-8.2.0.tgz",
+      "integrity": "sha512-o2r4QW5+R7CZR41E7bdifJ7wB4mLqQ8NwQsAf6FCC7oRs11pi2zDdASR6Ln7VU9Nqz6MT2bs7Rvn6Vkv7D3IJw==",
       "license": "UNLICENSED",
       "dependencies": {
         "@forge/i18n": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@fastify/autoload": "~5.7.1",
     "@fastify/sensible": "~5.2.0",
-    "@forge/manifest": "^8.1.0",
+    "@forge/manifest": "^8.2.0",
     "@swc/helpers": "0.5.11",
     "axios": "1.6.7",
     "fastify": "~4.13.0",


### PR DESCRIPTION
Updated to version 8.2.0. This should include the `nodejs22.x` runtime value. Should fix #138.