### PR TITLE
fix: release dependency updates as patch

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,7 +5,15 @@
     { "name": "test-*", "prerelease": true}
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    ["@semantic-release/commit-analyzer", {
+      "releaseRules": [
+        {
+          "type": "build",
+          "scope": "deps",
+          "release": "patch"
+        }
+      ]
+    }],
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm", {
       "pkgRoot": "dist/packages/nx-forge"


### PR DESCRIPTION
update the semantic release configuration to publish dependency updates with a patch version bump