### PR TITLE
fix: support string resource interpolators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fastify/autoload": "~5.7.1",
         "@fastify/sensible": "~5.2.0",
-        "@forge/manifest": "^8.3.0",
+        "@forge/manifest": "^8.6.0-next.1",
         "@swc/helpers": "0.5.11",
         "axios": "1.6.7",
         "fastify": "~4.13.0",
@@ -13222,9 +13222,9 @@
       }
     },
     "node_modules/@forge/manifest": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-8.3.0.tgz",
-      "integrity": "sha512-SKTMevZUbiiSgdBgyrJgnS4WNyx4iU42a2IbU2vxIPrOya5XQO9UIf9w3xltwyqo3qzAjiVxGOP+tZ04jw/5qg==",
+      "version": "8.6.0-next.1",
+      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-8.6.0-next.1.tgz",
+      "integrity": "sha512-zWTwM9aMu+h/bG/E7+629tVbdkFDmYi/LnfhJE3QaDn25n/vANuWCQgs4IXgmycC3K5zjIAgag9njkyWqxKVCA==",
       "license": "UNLICENSED",
       "dependencies": {
         "@forge/i18n": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fastify/autoload": "~5.7.1",
     "@fastify/sensible": "~5.2.0",
-    "@forge/manifest": "^8.3.0",
+    "@forge/manifest": "^8.6.0-next.1",
     "@swc/helpers": "0.5.11",
     "axios": "1.6.7",
     "fastify": "~4.13.0",

--- a/packages/nx-forge/package.json
+++ b/packages/nx-forge/package.json
@@ -7,7 +7,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
-    "@forge/manifest": "^8.3.0",
+    "@forge/manifest": "^8.6.0-next.1",
     "@nx/devkit": "20.3.1",
     "@nx/eslint": "20.3.1",
     "@nx/jest": "20.3.1",


### PR DESCRIPTION
update @forge/manifest to 8.6.0-next.1 which includes a fix string resource interpolators to resolve resources relative to the actual location of the manifest.yml

Closes #137