### PR TITLE
fix: regression for modal resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fastify/autoload": "~5.7.1",
         "@fastify/sensible": "~5.2.0",
-        "@forge/manifest": "^8.3.0",
+        "@forge/manifest": "^8.6.0",
         "@swc/helpers": "0.5.11",
         "axios": "1.6.7",
         "fastify": "~4.13.0",
@@ -13222,9 +13222,9 @@
       }
     },
     "node_modules/@forge/manifest": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-8.3.0.tgz",
-      "integrity": "sha512-SKTMevZUbiiSgdBgyrJgnS4WNyx4iU42a2IbU2vxIPrOya5XQO9UIf9w3xltwyqo3qzAjiVxGOP+tZ04jw/5qg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-8.6.0.tgz",
+      "integrity": "sha512-qtc1EntYUSmAxTO1sCkN5AWCyvCmzTsbWJ4ExL+SJ4J5CQdktRJgsGQWIx+4XlADDM1LHQyTtoqW4SSE1BMX4w==",
       "license": "UNLICENSED",
       "dependencies": {
         "@forge/i18n": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fastify/autoload": "~5.7.1",
     "@fastify/sensible": "~5.2.0",
-    "@forge/manifest": "^8.3.0",
+    "@forge/manifest": "^8.6.0",
     "@swc/helpers": "0.5.11",
     "axios": "1.6.7",
     "fastify": "~4.13.0",

--- a/packages/nx-forge/package.json
+++ b/packages/nx-forge/package.json
@@ -7,7 +7,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
-    "@forge/manifest": "^8.3.0",
+    "@forge/manifest": "^8.6.0",
     "@nx/devkit": "20.3.1",
     "@nx/eslint": "20.3.1",
     "@nx/jest": "20.3.1",
@@ -15,6 +15,7 @@
     "@nx/webpack": "20.3.1",
     "fs-extra": "^10.0.1",
     "js-yaml": "^4.1.0",
+    "yaml": "*",
     "jsonata": "^2.0.5",
     "tslib": "^2.3.0"
   },

--- a/packages/nx-forge/src/executors/build/lib/patch-manifest-yml.ts
+++ b/packages/nx-forge/src/executors/build/lib/patch-manifest-yml.ts
@@ -38,7 +38,9 @@ export async function patchManifestYml(options: Options) {
 
   logger.info(`Patching ${manifestPath}...`);
 
-  const manifestSchema = await readManifestYml(manifestPath);
+  const manifestSchema = await readManifestYml(manifestPath, {
+    interpolate: false,
+  });
 
   const patchedManifest = patchManifestInternal(
     absoluteOutputPath,
@@ -60,17 +62,17 @@ function patchManifestInternal(
   const uiResources = resources.filter(
     isResourceType(manifestSchema, ['ui-kit', 'custom-ui'])
   );
-  const genericResources = resources.filter(
-    isResourceType(manifestSchema, ['generic'])
+  const staticResources = resources.filter(
+    isResourceType(manifestSchema, ['static'])
   );
 
   // Integrity check: We want to be sure that we are not losing any resource
-  // definitions when separating them into UI and generic resources.
+  // definitions when separating them into UI and static resources.
   const resourceKeySet = new Set(resources.map((r) => r.key));
   const uiResourcesKeySet = new Set(uiResources.map((r) => r.key));
-  const genericResourcesKeySet = new Set(genericResources.map((r) => r.key));
+  const staticResourcesKeySet = new Set(staticResources.map((r) => r.key));
   const missingResourceKeys = [...resourceKeySet].filter(
-    (k) => !uiResourcesKeySet.has(k) && !genericResourcesKeySet.has(k)
+    (k) => !uiResourcesKeySet.has(k) && !staticResourcesKeySet.has(k)
   );
   if (missingResourceKeys.length > 0) {
     logger.warn(
@@ -88,7 +90,7 @@ function patchManifestInternal(
           ...resource,
           path: `${options.resourcePath}/${resource.path}`,
         })),
-        ...genericResources,
+        ...staticResources,
       ],
     };
   } else {
@@ -105,7 +107,7 @@ function patchManifestInternal(
             resourceTypeIndex[r.key]
           )
         ),
-        ...genericResources,
+        ...staticResources,
       ],
     };
   }

--- a/packages/nx-forge/src/executors/build/lib/process-resource-dependencies.ts
+++ b/packages/nx-forge/src/executors/build/lib/process-resource-dependencies.ts
@@ -39,7 +39,9 @@ export async function processResourceDependencies(
     context.projectsConfigurations.projects[context.projectName].root,
     'manifest.yml'
   );
-  const manifestSchema = await readManifestYml(manifestPath);
+  const manifestSchema = await readManifestYml(manifestPath, {
+    interpolate: false,
+  });
   const resources = manifestSchema.resources ?? [];
   const uiResources = resources.filter(
     isResourceType(manifestSchema, ['ui-kit', 'custom-ui'])

--- a/packages/nx-forge/src/graph/create-dependencies.ts
+++ b/packages/nx-forge/src/graph/create-dependencies.ts
@@ -15,7 +15,9 @@ const getUIResourceDependencies = async (
   [projectName, manifestFile]: [string, FileData],
   context: CreateDependenciesContext
 ): Promise<RawProjectGraphDependency[]> => {
-  const manifestSchema = await readManifestYml(manifestFile.file);
+  const manifestSchema = await readManifestYml(manifestFile.file, {
+    interpolate: false,
+  });
   const uiResourceProjectNames = extractUIResourceProjectNames(manifestSchema);
 
   const getUIResourceStaticDependency = (

--- a/packages/nx-forge/src/utils/forge/yaml-validator.ts
+++ b/packages/nx-forge/src/utils/forge/yaml-validator.ts
@@ -1,0 +1,80 @@
+import {
+  ManifestObject,
+  ManifestParserBuilder,
+  errors,
+  References,
+} from '@forge/manifest';
+import { readFileSync } from 'node:fs';
+import { YAMLError } from 'yaml';
+import { ValidatorInterface } from '@forge/manifest/out/validators/validator-interface';
+import { ManifestValidationResult } from '@forge/manifest/out/types';
+
+/**
+ * Copy of @forge/manifest YamlValidator with the only difference that the
+ * validator can be constructed with or without manifest interpolation. The
+ * validator provided by @forge/manifest does not provide an option to skip
+ * interpolation.
+ */
+class YamlValidator<T>
+  implements ValidatorInterface<ManifestObject<T> | undefined, T>
+{
+  constructor(protected options: { interpolate: boolean }) {}
+  async validate(
+    manifest: ManifestObject<T> | undefined
+  ): Promise<ManifestValidationResult<T>> {
+    if (!manifest?.filePath) {
+      return {
+        success: false,
+        manifestObject: manifest,
+      };
+    }
+    try {
+      const content = readFileSync(manifest.filePath, 'utf8');
+      const parserBuilder = this.options.interpolate
+        ? new ManifestParserBuilder().withInterpolators()
+        : new ManifestParserBuilder();
+      const manifestContent = parserBuilder
+        .build()
+        .parseManifest({ content, filePath: manifest.filePath });
+      return {
+        success: true,
+        manifestObject: {
+          filePath: manifest.filePath,
+          yamlContent: manifestContent,
+          yamlContentByLine: content.split('\n'),
+        },
+      };
+    } catch (e) {
+      if (e instanceof YAMLError) {
+        const pos = e.linePos?.[0];
+        return {
+          success: false,
+          errors: [
+            {
+              message: errors.invalidManifest(
+                e.message.replace(/(at line).+/gms, '').trim()
+              ),
+              reference: References.InvalidManifest,
+              level: 'error',
+              line: pos?.line ?? 0,
+              column: pos?.col ?? 0,
+            },
+          ],
+        };
+      }
+      return {
+        success: false,
+        errors: [
+          {
+            message: errors.invalidManifest(e.message),
+            reference: References.InvalidManifest,
+            level: 'error',
+            line: 0,
+            column: 0,
+          },
+        ],
+      };
+    }
+  }
+}
+export default YamlValidator;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2018",
     "module": "esnext",
     "lib": ["es2022", "dom"],
     "skipLibCheck": true,


### PR DESCRIPTION
update the resource type inference logic to detect modal resources as UI resources even if they are not referenced by a module directly, load and patch manifest.yml without interpolation

Closes #150, #137