### PR TITLE
fix: load manifest without interpolation

### DIFF
--- a/packages/nx-forge/src/executors/deploy/lib/transform-manifest-yml.ts
+++ b/packages/nx-forge/src/executors/deploy/lib/transform-manifest-yml.ts
@@ -33,7 +33,7 @@ export const transformManifestYml = async (
     'manifest.yml'
   );
 
-  const manifest = await readManifestYml(manifestPath);
+  const manifest = await readManifestYml(manifestPath, { interpolate: false });
 
   expression.registerFunction(
     'env',

--- a/packages/nx-forge/src/executors/register/lib/patch-manifest-yml.ts
+++ b/packages/nx-forge/src/executors/register/lib/patch-manifest-yml.ts
@@ -16,7 +16,9 @@ export async function patchManifestYml(options: NormalizedOptions) {
     options.outputPath,
     'manifest.yml'
   );
-  const outputManifestSchema = await readManifestYml(outputManifestPath);
+  const outputManifestSchema = await readManifestYml(outputManifestPath, {
+    interpolate: false,
+  });
 
   const appId: string = outputManifestSchema.app.id;
 
@@ -24,7 +26,9 @@ export async function patchManifestYml(options: NormalizedOptions) {
     options.projectRoot,
     'manifest.yml'
   );
-  const projectManifestSchema = await readManifestYml(projectManifestPath);
+  const projectManifestSchema = await readManifestYml(projectManifestPath, {
+    interpolate: false,
+  });
 
   logger.info(
     `Patching project manifest ${projectManifestPath} with app id ${appId}...`

--- a/packages/nx-forge/src/executors/tunnel/lib/extract-custom-ui-projects.ts
+++ b/packages/nx-forge/src/executors/tunnel/lib/extract-custom-ui-projects.ts
@@ -42,7 +42,9 @@ async function extractVerifiedCustomUIProjects(
     context.projectsConfigurations.projects[context.projectName].root,
     'manifest.yml'
   );
-  const manifestSchema = await readManifestYml(manifestPath);
+  const manifestSchema = await readManifestYml(manifestPath, {
+    interpolate: false,
+  });
   const resources: Resources = manifestSchema.resources ?? [];
   return resources
     .filter(isResourceType(manifestSchema, ['custom-ui']))


### PR DESCRIPTION
ensure the plugin always loads the manifest.yml without interpolation

Closes #155