### PR TITLE
feat: delete resource project output path on package

### DIFF
--- a/packages/nx-forge/src/executors/build/lib/process-resource-dependencies.ts
+++ b/packages/nx-forge/src/executors/build/lib/process-resource-dependencies.ts
@@ -163,7 +163,7 @@ const verifyAndCopyResourceDependency = (
     resourceProjectName
   );
 
-  if (!directoryExists(absoluteResourceOutputPath)) {
+  if (directoryExists(absoluteResourceOutputPath)) {
     rmSync(absoluteResourceOutputPath, { recursive: true });
   }
 


### PR DESCRIPTION
delete resource project output path before copying new resource files

Closes #164