### PR TITLE
fix(deps): update Forge package dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fastify/autoload": "~5.7.1",
         "@fastify/sensible": "~5.2.0",
-        "@forge/manifest": "^8.6.0",
+        "@forge/manifest": "^9.1.0",
         "@swc/helpers": "0.5.11",
         "axios": "1.6.7",
         "fastify": "~4.13.0",
@@ -13213,21 +13213,21 @@
       }
     },
     "node_modules/@forge/i18n": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@forge/i18n/-/i18n-0.0.2.tgz",
-      "integrity": "sha512-xCkFPVX8vf9q0HCxqt8krvzE1i/MFeTETjnSGqUjSil4dXejVffmM6sc/xgwSHVVGLQqz9sBu7TKF3faw4daqA==",
-      "license": "UNLICENSED",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@forge/i18n/-/i18n-0.0.5.tgz",
+      "integrity": "sha512-G4M8NTXbNR5HzpYNFQMczypUuxoItdtAMQmwIgUkzE2osrjPRKhFx/VniMGnnXoowgmDLoaMtMcllvxcm/YnVA==",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/@forge/manifest": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-8.6.0.tgz",
-      "integrity": "sha512-qtc1EntYUSmAxTO1sCkN5AWCyvCmzTsbWJ4ExL+SJ4J5CQdktRJgsGQWIx+4XlADDM1LHQyTtoqW4SSE1BMX4w==",
-      "license": "UNLICENSED",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@forge/manifest/-/manifest-9.1.0.tgz",
+      "integrity": "sha512-3K3k3XTRDGHv43lxrzwZljFBNVQNsMMJP24EzHf42MqIITlQPxmwEEW8iBmXQdRAe5QSuYCFTy3wJOKx/xgRBg==",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@forge/i18n": "0.0.2",
+        "@forge/i18n": "0.0.5",
         "@sentry/node": "7.106.0",
         "ajv": "^8.12.0",
         "ajv-formats": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@fastify/autoload": "~5.7.1",
     "@fastify/sensible": "~5.2.0",
-    "@forge/manifest": "^8.6.0",
+    "@forge/manifest": "^9.1.0",
     "@swc/helpers": "0.5.11",
     "axios": "1.6.7",
     "fastify": "~4.13.0",

--- a/packages/nx-forge/package.json
+++ b/packages/nx-forge/package.json
@@ -7,7 +7,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
-    "@forge/manifest": "^8.6.0",
+    "@forge/manifest": "^9.1.0",
     "@nx/devkit": "20.3.1",
     "@nx/eslint": "20.3.1",
     "@nx/jest": "20.3.1",


### PR DESCRIPTION
update @forge/manifest to version 9.1.0 supporting the latest manifest schema

Closes #168